### PR TITLE
Update repository in package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ node test.js
 
 ### History
 
+- Ver 0.0.7 Fix repository link in `package.json`
 - Ver 0.0.6 Bugfix
 - Ver 0.0.5 Some methods support chain operation
 - Ver 0.0.4 Add feature for `check` and `update`

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
   "name": "file-changed",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "A node module to check whether file is changed or not.",
   "main": "lib/main.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/poppinlp/node-timestamp"
+    "url": "https://github.com/poppinlp/file-changed"
   },
   "bugs": {
-    "url": "https://github.com/poppinlp/node-timestamp/issues"
+    "url": "https://github.com/poppinlp/file-changed/issues"
   },
   "author": {
     "name": "PoppinL",


### PR DESCRIPTION
on npm all links still point to [poppinlp/node-timestamp](https://github.com/poppinlp/node-timestamp), which is a 404. 

You should update the repo to point here and publish a new version on npm. If you'd like I could submit this as a pr.