### PR TITLE
Add support for custom change-db path

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -16,17 +16,17 @@ var fs = require('fs'),
         encoding: 'utf8'
     };
 
-function Timestamp (pathDb) {
+function Timestamp (changeDbPath) {
     var that = this;
     // check argument
-    if (typeof pathDb === 'undefined') {
-        pathDb = path.normalize(__dirname + '/../_timestamp.json')
+    if (typeof changeDbPath === 'undefined') {
+        changeDbPath = path.normalize(__dirname + '/../_timestamp.json');
     } else {
-        if (typeof pathDb !== 'string' || pathDb === '') {
-            throw new Error('pathDb argument must be a valid string.');
+        if (typeof changeDbPath !== 'string' || changeDbPath === '') {
+            throw new Error('changeDbPath argument must be a valid string.');
         }
     }
-    that._dataPath = pathDb;
+    that._dataPath = changeDbPath;
     /* save files list data
      * {
      *   filepath: {

--- a/lib/main.js
+++ b/lib/main.js
@@ -16,10 +16,17 @@ var fs = require('fs'),
         encoding: 'utf8'
     };
 
-function Timestamp () {
+function Timestamp (pathDb) {
     var that = this;
-    // save _timestamp.json file path
-    that._dataPath = path.normalize(__dirname + '/../_timestamp.json');
+    // check argument
+    if (typeof pathDb === 'undefined') {
+        pathDb = path.normalize(__dirname + '/../_timestamp.json')
+    } else {
+        if (typeof pathDb !== 'string' || pathDb === '') {
+            throw new Error('pathDb argument must be a valid string.');
+        }
+    }
+    that._dataPath = pathDb;
     /* save files list data
      * {
      *   filepath: {
@@ -144,4 +151,4 @@ Timestamp.prototype = {
     }
 };
 
-module.exports = new Timestamp();
+module.exports = Timestamp;

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   },
   "devDependencies": {
     "mocha": "^2.2.1",
+    "rimraf": "^2.6.1",
     "sync-exec": "^0.5.0"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -1,7 +1,10 @@
 var assert = require('assert'),
     fs = require('fs'),
     crypto = require('crypto'),
-    fc = require(require('path').normalize('../lib/main.js'));
+    Fc = require(require('path').normalize('../lib/main.js')),
+    rimraf = require('rimraf');
+
+var fc = new Fc();
 
 describe('file-changed API', function() {
     describe('#addFile', function() {
@@ -90,6 +93,39 @@ describe('file-changed API', function() {
             assert.strictEqual(fs.existsSync('_timestamp.json'), false, 'json file should not exist');
             fc.save();
             assert.strictEqual(fs.existsSync('_timestamp.json'), true, 'json file should exist');
+        });
+    });
+});
+
+describe('file-changed initializer', function() {
+    describe('#new without argument', function() {
+        before(function() {
+            rimraf.sync('_timestamp.json');
+        });
+        it('Save collection to default db file', function() {
+            assert.strictEqual(fs.existsSync('_timestamp.json'), false, 'json file should not exist');
+            var fcObj = new Fc();
+            fcObj.save();
+            assert.strictEqual(fs.existsSync('_timestamp.json'), true, 'json file should exist');
+        });
+    });
+    describe('#new with dbPath argument', function() {
+        before(function() {
+            fs.mkdirSync('tmp');
+        });
+        after(function() {
+            rimraf.sync('tmp');
+        });
+        var dbPath = require('path').join('tmp', 'myFcDatabase.json');
+        it('Save collection to custom db file', function() {
+            assert.strictEqual(fs.existsSync(dbPath), false, 'json file should not exist');
+            var fcObj = new Fc(dbPath);
+            fcObj.save();
+            assert.strictEqual(fs.existsSync(dbPath), true, 'json file should exist');
+        });
+        it('Throw error if dbPath is empty or it is not a string', function() {
+            var test = function() { var fcObj = new Fc([dbPath]); };
+            assert.throws(test, 'pathDb argument must be a valid string.', 'function should throw');
         });
     });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -109,23 +109,23 @@ describe('file-changed initializer', function() {
             assert.strictEqual(fs.existsSync('_timestamp.json'), true, 'json file should exist');
         });
     });
-    describe('#new with dbPath argument', function() {
+    describe('#new with changeDbPath argument', function() {
         before(function() {
             fs.mkdirSync('tmp');
         });
         after(function() {
             rimraf.sync('tmp');
         });
-        var dbPath = require('path').join('tmp', 'myFcDatabase.json');
+        var changeDbPath = require('path').join('tmp', 'myFcDatabase.json');
         it('Save collection to custom db file', function() {
-            assert.strictEqual(fs.existsSync(dbPath), false, 'json file should not exist');
-            var fcObj = new Fc(dbPath);
+            assert.strictEqual(fs.existsSync(changeDbPath), false, 'json file should not exist');
+            var fcObj = new Fc(changeDbPath);
             fcObj.save();
-            assert.strictEqual(fs.existsSync(dbPath), true, 'json file should exist');
+            assert.strictEqual(fs.existsSync(changeDbPath), true, 'json file should exist');
         });
-        it('Throw error if dbPath is empty or it is not a string', function() {
-            var test = function() { var fcObj = new Fc([dbPath]); };
-            assert.throws(test, 'pathDb argument must be a valid string.', 'function should throw');
+        it('Throw error if changeDbPath is empty or it is not a string', function() {
+            var test = function() { var fcObj = new Fc([changeDbPath]); };
+            assert.throws(test, 'changechangeDbPath argument must be a valid string.', 'function should throw');
         });
     });
 });


### PR DESCRIPTION
# Idea

file-changed module should be **instanced**, not used as static object. So you can declare, at instance time, the file path in which store the _**change database**_:

```javascript
var Fc = require('file-changed');
var fc = new Fc('mydb.json');
```

If you not pass argument, it use default file, `_timestamp.json`.

## Benefits

- you can use more than one _change database_ in the project and this can be useful in complex project;

- the _change database_ itself is no longer related to the `node_module` installation folder, so you can delete this folder without worries: the db is stored in your custom path.

## Implementation

The key edits is on the function `Timestamp` sign. 
In addition, now the module `export` the class `Timestamp`.

This change also involves a small change to the unit test module: the `fc` variable is instanced at the beginning, so unit test itself do not undergo any variation.

## Breaking change
Note this feature require a breaking change on API: the module can be used only if instanced, not as static.

## Issue resolution
This PR close the [issue#2](https://github.com/poppinlp/file-changed/issues/2).